### PR TITLE
fix ReportPortal history urls

### DIFF
--- a/src/extensions/report-portal-history.js
+++ b/src/extensions/report-portal-history.js
@@ -28,7 +28,7 @@ function getSymbols({ target, extension, launches }) {
   const symbols = [];
   for (let i = 0; i < launches.length; i++) {
     const launch = launches[i];
-    const launch_url = `${extension.inputs.url}/ui/#${extension.inputs.project}/launches/all/${launch.uuid}`;
+    const launch_url = `${extension.inputs.url}/ui/#${extension.inputs.project}/launches/all/${launch.launchId}`;
     let current_symbol = '⚠️';
     if (launch.status === 'PASSED') {
       current_symbol = '✅'; 


### PR DESCRIPTION
while using ReportPortal 5.6.0 history urls were not working using uuid attribute. 

Tested with "launchId" it's working as designed.